### PR TITLE
Fix the syntax of the `should_panic` attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic()]
+    #[should_panic]
     fn sides_less_than_one(){
         let sides = 0;
         let die = Die::new(sides);


### PR DESCRIPTION
Hi there!

The Rust compiler accidentally accepted certain invalid forms of the should_panic attribute.
This is being fixed in this change to the Rust compiler: https://github.com/rust-lang/rust/pull/143808
Because the change will break this project, I'm submitting a fix PR as a courtesy, this should make sure your project continues to build correctly on new versions of Rust